### PR TITLE
Switch to using static checksum

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -2,7 +2,9 @@
 $version = 'r23.2'
 $baseurl = "https://cdist2.perforce.com/perforce/$version"
 $url64 = "$baseurl/bin.ntx64/helix-p4-x64.exe"
-$checksum64 = ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'helix-p4-x64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
+
+# Get latest value with ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'helix-p4-x64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
+$checksum64 = 'f49f5951be69ae9618c094e089bc66b92a046dd7e42872f7e6f4cfd4328daaf6'
 
 $packageArgs = @{
   packageName    = $packageName


### PR DESCRIPTION
Based on the error at https://community.chocolatey.org/packages/p4/2023.2.0 I infer that you are no longer allowed to dynamically download a checksum file (without actually checking the checksum of that file, which is circular)

> Package automation scripts download a remote file without validating the checksum

There is a problem with the approach in this PR because Perforce release new patch releases over the top of the old releases (a bit like Chrome does) so the checksums need to be constantly updated for each patch release (or users tell Chocolatey to ignore them). Don't think that can be helped though?