### PR TITLE
Switch to CDN host

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = 'p4'
 $version = 'r24.1'
-$baseurl = "https://filehost.perforce.com/perforce/$version"
+$baseurl = "https://cdist2.perforce.com/perforce/$version"
 $url64 = "$baseurl/bin.ntx64/helix-p4-x64.exe"
 
 # Get latest value with ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'helix-p4-x64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]


### PR DESCRIPTION
filehost.perforce.com appears to be a centralised single host in the US West Coast, whereas cdist2.perforce.com is Cloudfront CDNed.

Probably better to use the CDN domains?