### PR TITLE
new hash for 25.1 p4

### DIFF
--- a/p4.nuspec
+++ b/p4.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>p4</id>
-    <version>2025.1.2810567</version>
+    <version>2025.1/2831954</version>
     <packageSourceUrl>https://github.com/ripclawffb/chocolatey-p4</packageSourceUrl>
     <owners>Asif Shaikh</owners>
     <title>P4: Helix Command-Line Client</title>

--- a/p4.nuspec
+++ b/p4.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>p4</id>
-    <version>2025.1/2831954</version>
+    <version>2025.1.2831954</version>
     <packageSourceUrl>https://github.com/ripclawffb/chocolatey-p4</packageSourceUrl>
     <owners>Asif Shaikh</owners>
     <title>P4: Helix Command-Line Client</title>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $baseurl = "https://filehost.perforce.com/perforce/$version"
 $url64 = "$baseurl/bin.ntx64/helix-p4-x64.exe"
 
 # Get latest value with ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'helix-p4-x64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
-$checksum64 = 'd0b7d61495b98ba024e2f0f3a414dd07f2021cb9c09cdef954d83439f837f424'
+$checksum64 = '4b5594a8d49d1f08b6ec086685c05b4b8eccae881c6e8114e3295a267193b11e'
 
 $packageArgs = @{
   packageName    = $packageName


### PR DESCRIPTION
```
PS C:\Users\danielj> $version = 'r25.1'
PS C:\Users\danielj> $baseurl = "https://filehost.perforce.com/perforce/$version"
PS C:\Users\danielj> $url64 = "$baseurl/bin.ntx64/helix-p4-x64.exe"
PS C:\Users\danielj> $packageName = 'p4'
PS C:\Users\danielj> ((Invoke-WebRequest "$baseurl/bin.ntx64/SHA256SUMS" -UseBasicParsing).RawContent.ToString().Split() | Select-String -Pattern 'helix-p4-x64.exe' -SimpleMatch -Context 1,0 ).ToString().Trim().Split()[0]
4b5594a8d49d1f08b6ec086685c05b4b8eccae881c6e8114e3295a267193b11e
```